### PR TITLE
Fix bundle name for cloud deployment

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -10,7 +10,7 @@ LDFLAGS += -X "github.com/mattermost/mattermost-app-servicenow/function.BuildHas
 GO_BUILD_FLAGS += -ldflags '$(LDFLAGS)'
 GO_TEST_FLAGS += -ldflags '$(LDFLAGS)'
 
-AWS_BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION)-aws.zip
+AWS_BUNDLE_NAME ?= bundle.zip
 
 ## run: runs the app locally
 .PHONY: run


### PR DESCRIPTION
#### Summary
I've deleted too much code in https://github.com/mattermost/mattermost-app-servicenow/pull/50. The bundle used for cloud needs to be named `dist/bundle.zip`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48099